### PR TITLE
Handle error response from alexa.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ var request = require('request'),
 function requestp(rankData, url) {
     return new Promise(function (resolve, reject) {
         request(url, function (error, response, html) {
+            if (response.statusCode >= 400){
+                reject(new Error(response.statusCode.toString() + ": " + response.statusMessage));
+            }
             if (!error) {
                 var $ = cheerio.load(html);
 


### PR DESCRIPTION
After many request to `alexa.com/siteinfo`, alexa reject the subsequent request (403: Forbidden). 
This changes will tell the user when the request to alexa is failed.